### PR TITLE
Update availableListCommands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-basic-ftp",
-  "version": "4.6.3",
+  "version": "4.6.5",
   "description": "FTP client for Node.js, supports FTPS over TLS, IPv6, Async/Await, and Typescript.",
   "main": "dist/index",
   "types": "dist/index",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -61,7 +61,7 @@ export class Client {
      * is requested. After that, `availableListCommands` will  hold only the first
      * entry that worked.
      */
-    availableListCommands = ["MLSD", "LIST -a", "LIST"]
+    availableListCommands = ["LIST"]
     /** Low-level API to interact with FTP server. */
     readonly ftp: FTPContext
     /** Tracks progress of data transfers. */

--- a/test/downloadSpec.js
+++ b/test/downloadSpec.js
@@ -170,7 +170,7 @@ describe("Download directory listing", function() {
 
     it("sends the right default command", function() {
         client.ftp.socket.once("didSend", command => {
-            assert.equal(command, "MLSD\r\n");
+            assert.equal(command, "LIST\r\n");
             sendCompleteList()
         });
         // This will throw an unhandled exception because we close the client when
@@ -181,7 +181,7 @@ describe("Download directory listing", function() {
 
     it("sends the right default command with optional path", function() {
         client.ftp.socket.once("didSend", command => {
-            assert.equal(command, "MLSD my/path\r\n", "Unexpected list command");
+            assert.equal(command, "LIST my/path\r\n", "Unexpected list command");
             sendCompleteList()
         });
         // This will throw an unhandled exception because we close the client when
@@ -191,7 +191,7 @@ describe("Download directory listing", function() {
     });
 
     it("tries all other list commands if default one fails", function() {
-        const expectedCandidates = ["MLSD", "LIST -a", "LIST"]
+        const expectedCandidates = ["LIST"]
         client.ftp.socket.on("didSend", command => {
             const expected = expectedCandidates.shift()
             assert.equal(command, expected + "\r\n", "Unexpected list command candidate");
@@ -212,14 +212,14 @@ describe("Download directory listing", function() {
             counter++
         });
         return client.list().catch(err => {
-            assert.equal(err.message, "501 Syntax error 3")
+            assert.equal(err.message, "501 Syntax error 1")
         });
     })
 
     it("uses first successful list command for all subsequent requests", function() {
         const promise = client.list().then(result => {
             assert.deepEqual(result, expList);
-            assert.deepEqual(["MLSD"], client.availableListCommands)
+            assert.deepEqual(["LIST"], client.availableListCommands)
         });
         setTimeout(() => sendCompleteList());
         return promise


### PR DESCRIPTION
RBC Server doesn't like non LIST commands, and stops accepting new commands after one fails. Let's just use the one that works with RBC by default.